### PR TITLE
.\cordova does not work, needs to be %~dp0\cordova

### DIFF
--- a/broker/cordova.cmd
+++ b/broker/cordova.cmd
@@ -1,7 +1,7 @@
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe"  ".\cordova" %*
+  "%~dp0\node.exe" "%~dp0\cordova" %*
 ) ELSE (
   @SETLOCAL
   @SET PATHEXT=%PATHEXT:;.JS;=;%
-  node  ".\cordova" %*
+  node "%~dp0\cordova" %*
 )


### PR DESCRIPTION
The ".\cordova" construction only works if you are in the .cvm directory when you run this script. The problem is that "." is interpreted as the current directory from where you issued the command, it does not represent where the script file was found. Assuming "cordova.cmd" is located in %HOMEPATH%\.cvm (and assuming your PATH is setup correctly), if you issue the "cordova" command from anywhere but the %HOMEPATH%\.cvm directory, the ".\cordova" construct will fail.